### PR TITLE
Fix revert when user is proxy admin

### DIFF
--- a/test/BaseFixture.sol
+++ b/test/BaseFixture.sol
@@ -11,6 +11,7 @@ import {SafeCast} from "@openzeppelin5/contracts/utils/math/SafeCast.sol";
 import {Ownable} from "@openzeppelin5/contracts/access/Ownable.sol";
 import {Math} from "@openzeppelin5/contracts/utils/math/Math.sol";
 import {Clones} from "@openzeppelin5/contracts/proxy/Clones.sol";
+import {ERC1967Utils} from "@openzeppelin5/contracts/proxy/ERC1967/ERC1967Utils.sol";
 
 import {ICrosschainERC20, ISuperchainERC20, IXERC20, XERC20} from "src/xerc20/XERC20.sol";
 import {IXERC20Lockbox, XERC20Lockbox} from "src/xerc20/XERC20Lockbox.sol";
@@ -76,6 +77,12 @@ abstract contract BaseFixture is Test, TestConstants, GasSnapshot {
         lockbox = XERC20Lockbox(_lockbox);
 
         labelContracts();
+    }
+
+    function _admin() internal view returns (address) {
+        bytes32 adminSlot = ERC1967Utils.ADMIN_SLOT;
+        bytes32 value = vm.load(address(xVelo), adminSlot);
+        return address(uint160(uint256(value)));
     }
 
     function labelContracts() public virtual {

--- a/test/unit/fuzz/xerc20/XERC20/crosschainMint/crosschainMint.t.sol
+++ b/test/unit/fuzz/xerc20/XERC20/crosschainMint/crosschainMint.t.sol
@@ -10,6 +10,9 @@ contract CrosschainMintUnitFuzzTest is XERC20Test {
         // It should revert with {OnlySuperchainERC20Bridge}
         vm.assume(_user != SUPERCHAIN_ERC20_BRIDGE);
 
+        // It will revert with {ProxyDeniedAdminAccess} if _user is the admin
+        vm.assume(_user != _admin());
+
         vm.prank(_user);
         vm.expectRevert(ISuperchainERC20.OnlySuperchainERC20Bridge.selector);
         xVelo.crosschainMint({_to: users.charlie, _amount: TOKEN_1});


### PR DESCRIPTION
```
Encountered 1 failing test in test/unit/fuzz/xerc20/XERC20/crosschainMint/crosschainMint.t.sol:CrosschainMintUnitFuzzTest
[FAIL: Error != expected error: ProxyDeniedAdminAccess() != OnlySuperchainERC20Bridge(); counterexample: calldata=0xb4e890e4000000000000000000000000fcff1553411818540322cba26669e7fe416c394c args=[0xFCFF1553411818540322CBa26669e7Fe416c394c]] testFuzz_WhenCallerIsNotSuperchainERC20Bridge(address) (runs: 165, μ: 16567, ~: 16567)
```